### PR TITLE
T-180

### DIFF
--- a/Ping!/Ping!/ViewController.swift
+++ b/Ping!/Ping!/ViewController.swift
@@ -250,12 +250,13 @@ class ViewController: UIViewController, CLLocationManagerDelegate, MKMapViewDele
                    
                     let current_date = Date()
                     //Declare number of days to go back
-                    let history_days = -5
+                    //Will be replaced by a user defaults selection made in settings
+                    let history_days = -7
                     //Determine starting point of history
-                    let history_limit = (Calendar.current.date(byAdding: .day, value: history_days, to: Date()))
+                    let history_limit = (Calendar.current.date(byAdding: .day, value: history_days, to: current_date))
                     //Debug
-                    print("Today's date is ", current_date)
-                    print("Breadcrumbs will only go as far as: ", history_limit!)
+                    //print("History: Today's date is ", current_date)
+                    //print("History: Breadcrumbs will only go as far as: ", history_limit!)
                     
                     for h in history{
                         //Converting string to date object
@@ -267,8 +268,11 @@ class ViewController: UIViewController, CLLocationManagerDelegate, MKMapViewDele
                         i = i + 1
                         }
                     }
+                    //TODO: Check if user has enabled breadcrumbs
+                    if(points.count > 0) {
                     let myPolyline = MKPolyline(coordinates: points, count: i)
                     self.mapView.add(myPolyline)
+                    }
                 }
             }
             // remove any unreferenced annotations

--- a/Ping!/Ping!/ViewController.swift
+++ b/Ping!/Ping!/ViewController.swift
@@ -247,10 +247,25 @@ class ViewController: UIViewController, CLLocationManagerDelegate, MKMapViewDele
                     // TODO: Show breadcrumbs on map. For now, just printing history data
                     var i = 0 as Int
                     var points = [CLLocationCoordinate2D]()
+                   
+                    let current_date = Date()
+                    //Declare number of days to go back
+                    let history_days = -5
+                    //Determine starting point of history
+                    let history_limit = (Calendar.current.date(byAdding: .day, value: history_days, to: Date()))
+                    //Debug
+                    print("Today's date is ", current_date)
+                    print("Breadcrumbs will only go as far as: ", history_limit!)
+                    
                     for h in history{
+                        //Converting string to date object
+                        let history_data = h.history_Location_datetime.toDate(dateFormat:"yyyy-MM-dd HH:mm:ss zz")
+                        //Add to array if within limit
+                        if (history_data > history_limit!) {
                         let myLoc = CLLocationCoordinate2D(latitude:Double(h.history_Location_latitude)!, longitude:Double(h.history_Location_longitude)!)
                         points.append(myLoc)
                         i = i + 1
+                        }
                     }
                     let myPolyline = MKPolyline(coordinates: points, count: i)
                     self.mapView.add(myPolyline)


### PR DESCRIPTION
Allow setting a date range for history breadcrumbs.
The current default is 7 days from current date.
To be replaced by multiple options provided in settings.